### PR TITLE
Test_odmrpulser

### DIFF
--- a/dpg11.py
+++ b/dpg11.py
@@ -1,0 +1,209 @@
+import numpy as np 
+# Import dpg11 driver
+from dpg11_pylib import driver, waveforms
+# Import the qt3utils classes 
+from qt3utils.pulsers.interface import ExperimentPulser
+from qt3utils.errors import PulseTrainWidthError
+
+# from pulseblaster.PBInd import PBInd
+
+# Create the dpg11 pulser class
+class DPG11Pulser(ExperimentPulser):
+    
+    def start(self):
+        '''
+        Start the DPG11 output.
+        '''
+        self.pulser.run(execute=True)
+        
+    def stop(self):
+        '''
+        Stop the DPG11 output.
+        '''
+        self.pulser.stop(execute=True)
+
+# Create the cwodmr class for the dpg11
+class DPG11CWODMRPulser(DPG11Pulser):
+    '''
+    Programs the pulse sequences needed for CWODMR.
+
+    Provides an
+      * always ON channel for an AOM.
+      * 50% duty cycle pulse for RF switch
+      * clock signal for use with a data acquisition card
+      * trigger signal for use with a data acquisition card
+    '''
+    def __init__(self, dpg11_driver,
+                 rf_channel=1,
+                 aom_channel=2,
+                 clock_channel=3,
+                 trigger_channel=4,
+                 rf_pulse_duration=5e-6,
+                 clock_period=200e-9,
+                 trigger_width=500e-9):
+        '''
+        Parameters
+        ----------
+        dpg11_driver : DPG11Device
+            DPG11Device object from the dpg11_pylib.driver package.
+        rf_channel : int
+            Channel to use for the RF switch. Default is 1.
+        aom_channel : int
+            Channel to use for the AOM. Controls the postive voltage on the AOM Default is 2.
+        clock_channel : int
+            Channel to use for the clock signal on the NI DAQ card. Default is 3.
+        trigger_channel : int
+            Channel to use for the trigger signal. Provides a rising edge trigger for the NI DAQ card Default is 4.
+        rf_pulse_duration : float
+            Duration of the RF pulse in seconds. Default is 5e-6.
+        clock_period : float
+            Period of the clock signal in seconds. Default is 200e-9.
+        trigger_width : float
+            Width of the trigger signal in seconds. Default is 500e-9.
+        '''
+        self.pulser = dpg11_driver
+        self.rf_channel = rf_channel
+        self.aom_channel = aom_channel
+        self.clock_channel = clock_channel
+        self.trigger_channel = trigger_channel
+        self.rf_pulse_duration = rf_pulse_duration
+        self.clock_period = clock_period
+        self.trigger_width = trigger_width
+        
+        # add the limits of the dpg11
+        # self.clock_limits = [50e6, 2.5e9]
+        self.clock_limits = self.pulser.internal_clock_rate_limits_in_hz
+
+    def experimental_conditions(self):
+        '''
+        Returns a dictionary of paramters that are pertinent for the relevant experiment
+        '''
+        return {
+            'rf_pulse_duration':self.rf_pulse_duration,
+            'clock_period':self.clock_period
+        }
+    
+    # Create the function to raise an error if the pulse width is too small
+    # TODO: Update to the limits of our devices
+    def raise_for_pulse_width(self, rf_pulse_duration, *args, **kwargs):
+        if rf_pulse_duration < 10e-9:
+            raise PulseTrainWidthError(f'RF width too small {int(rf_pulse_duration)} < 10 ns')
+    
+    # Create error function for checking if the clock rate is too small or too high
+    def raise_for_clock_rate(self, clock_rate, *args, **kwargs):
+        if clock_rate > self.clock_limits[1]:
+            raise ValueError(f'Clock rate too large {clock_rate} > {self.clock_limits[1]}')
+        if clock_rate < self.clock_limits[0]:
+            raise ValueError(f'Clock rate too small {clock_rate} < {self.clock_limits[0]}')
+    
+    # create function to reset the pulser. This may be needed for the dpg11
+    # TODO: Populate this function if we determine it is necessary
+    def reset_pulser(self, num_resets = 2):
+
+        # the QC Sapphire can enter weird states sometimes.
+        # Observation shows that multiple resets, followed by some delay
+        # results in a steady state for the pulser
+        print("reset :)")
+        # for i in range(num_resets):
+        #     self.pulser.set_all_state_off()
+        
+
+    # Create the function to program the pulse sequence
+    def program_pulser_state(self, rf_pulse_duration = None, *args, **kwargs):
+        '''
+        Program the pulser to generate a signals on all channels --
+        RF channel, clock channel and trigger channel.
+
+        Allows the user to set a different rf_pulse_duration after object instantiation.
+
+        Note that, in this current implementation, the rf width is half the
+        full cycle width of the pulser. That is, one full cycle is RF on for
+        time 'rf_pulse_duration', followed by RF off for time 'rf_pulse_duration'.
+
+        For CWODMR with the DPG11 right now, the optical pumping laser must
+        be on continuously through external means (typically, this is achieved
+        either by removing the AOM or by holding 3.3V on the AOM switch).
+
+        Note that the pulser will be in the OFF state after calling this function.
+        Call self.start() for the DPG11 to start generating signals.
+
+        returns
+            int: N_clock_ticks_per_cycle
+        '''
+        # Reset device, see if this is necessary in the future.
+        # self.reset_pulser() # based on experience, we have to do this in order for the system to behave correctly... :(
+        
+        # Set the pulser clock cycle
+        # get the clock rate
+        self.clock_rate = 1/self.clock_period
+        
+        # check if the clock rate is within the limits of the dpg11
+        # the dpg11 has a rather high min freq (25 MHz) which is larger than the max freq of the ni daq card
+        # so we need to emulate the clock rate. This will lead to a self.freq_multiplier that will 
+        # need to be carried through all of the waveform arrays. I will create the functions 
+        # to create these arrays to accomodate for this multiplier. If not too small, then freq_multiplier = 1
+        # check if too small
+        if self.clock_rate < self.clock_limits[0]:
+            # emulate the frequency until it hits the proper limits
+            self.sample_rate, self.freq_multiplier = waveforms.downconvert_clock_frequency(self.clock_rate, 
+                                                                                           self.clock_limits[0])
+        else:
+            # Check if the clock rate is too large
+            self.raise_for_clock_rate(self.clock_rate)
+            self.sample_rate = self.clock_rate
+            
+        # print(f'Sample rate: {self.sample_rate}')
+            
+        # stop any output of the dpg11 and set the sample_rate
+        # This may take some time since the file needs to be created and ran. I will test 
+        # this later and see if it becomes an issue
+        self.pulser.stop_ouput_set_clk(self.sample_rate)
+
+        
+        # setup the rf pulse 
+        if rf_pulse_duration:
+            self.raise_for_pulse_width(rf_pulse_duration)
+            self.rf_pulse_duration = np.round(rf_pulse_duration, 8)
+        # Make sure that the rf_pulse_duration is not too small
+        else:
+            self.raise_for_pulse_width(self.rf_pulse_duration)
+        # get mod 64 samples and duration for rf pulse
+        self.rf_pulse_samples, self.rf_pulse_duration = waveforms.length_mod_64(self.rf_pulse_duration,
+                                                                                self.sample_rate)
+        
+        # Set the cycle in terms of the number of samples  and time
+        cycle_samples = self.rf_pulse_samples*2
+        cycle_time = self.rf_pulse_duration*2
+        trigger_samples = int(self.trigger_width*self.sample_rate)
+        
+        
+        # Create all of the waveforms for the different channels
+        # rf waveform that is on for the rf_pulse_duration and off for the rest of the cycle
+        rf_waveform = waveforms.pad_waveform(waveform = np.ones(self.rf_pulse_samples),
+                                             length = cycle_samples)
+        # aom waveform that is on for the whole time
+        aom_waveform = np.ones(cycle_samples).astype(int)
+        # clock waveform for the while cycle
+        clock_waveform = waveforms.offOnArray(size=self.freq_multiplier,
+                                              length=cycle_samples)
+        # trigger waveform that is on for the trigger_width and off for the rest of the cycle?
+        trigger_waveform = waveforms.pad_waveform(waveform = np.ones(trigger_samples),
+                                                  length=cycle_samples)
+        
+        # Create the waveform dictionary to create the full waveform on all channels
+        waveform_dict = {self.rf_channel:rf_waveform,
+                         self.aom_channel:aom_waveform,
+                         self.clock_channel:clock_waveform,
+                         self.trigger_channel:trigger_waveform}
+        
+        # print(waveform_dict)
+        # Create the wavefile
+        self.wavefile_name = self.pulser.create_wave_file(wave_name='cwodmr_wave',
+                                                          wave_dict=waveform_dict)
+        # Load the wavefile onto the dpg11. It won't execute until the user calls the run function
+        self.pulser.create_single_segment(self.wavefile_name,
+                                          execute = True)
+        
+                                                  
+        
+        

--- a/dpg11_pylib/__init__.py
+++ b/dpg11_pylib/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.1.dev0'
+__version__ = '0.1.0'
 __author__ = 'Ethan R. Hansen'
 
 

--- a/dpg11_pylib/driver/dpg11.py
+++ b/dpg11_pylib/driver/dpg11.py
@@ -15,6 +15,9 @@ import numpy as np
 
 import inspect
 
+# from qt3utils.pulsers import qcsapphire, pulseblaster
+# from qt3utils.experiments import cwodmr
+
 
 # TODO: Get the class updated to work with the script method
 # TODO: Add proper docstrings for all of the functions, update the error calling using that new function
@@ -30,7 +33,7 @@ class DPG11Device:
     """
 
     # Hardware limited options
-    internal_clock_rate_limits_in_hz = [25e6, 2.5e9]
+    internal_clock_rate_limits_in_hz = [50e6, 2.5e9]
     device_output_channels = [i for i in range(1, 12)]
     memory_limits = [48, 8e6]
     loops_limits = [0, 2 ** 16 - 2]
@@ -605,7 +608,7 @@ class DPG11Device:
         Parameters
         ----------
         clock_rate : float
-            What to set the clock rate of the DPG11 as. Must be between 25 MHz and 2.5 GHz
+            What to set the clock rate of the DPG11 as. Must be between 50 MHz and 2.5 GHz
         execute: bool, optional
             If true, creates an executes a single-line script with just this function, by default False
 
@@ -959,58 +962,7 @@ class DPG11Device:
                                   overwrite_script=overwrite_script,
                                   save_script=save_script)
 
-    # Function that allowed for multi-channel outputs
-    # This does not work anymore with the new way the DPG11 works 
-    # def run_multi_channel(self,
-    #                       single_df: pd.DataFrame,
-    #                       multi_df: pd.DataFrame,
-    #                       clock_rate: float,
-
-    #                       save_script: bool = False,
-    #                       script_name: str = 'temp_script',
-    #                       overwrite_script: bool = True,
-
-    #                       soft_trig: bool = True):
-
-    #     # Creation of the initial command_list
-    #     command_list = [
-    #         self.stop(),
-    #         self.set_clk_rate(clock_rate=clock_rate)]
-
-    #     # Go through the single wave df
-    #     for index, row in single_df.iterrows():
-    #         command_list.append(
-    #             self.create_single_segment(
-    #                 channel_num=row['channel_num'],
-    #                 wave_filename=row['wave_filename'],
-    #                 num_loops=row['num_loops'],
-    #                 pad_begin=row['pad_begin'],
-    #                 pad_end=row['pad_end'],
-    #                 triggered=row['triggered']
-    #             )
-    #         )
-
-    #     # Go through the multi wave df
-    #     for index, row in multi_df.iterrows():
-    #         command_list.append(
-    #             self.create_multi_segments(
-    #                 channel_num=row['channel_num'],
-    #                 waves_filename=row['waves_filename'],
-    #                 pad_begin=row['pad_begin'],
-    #                 pad_end=row['pad_end'],
-    #                 loop=row['loop']
-    #             )
-    #         )
-
-    #     # Now append the run command
-    #     command_list.append(self.run(soft_trig=soft_trig))
-
-    #     # Create and run the script
-    #     return self.create_script(command_list=command_list,
-    #                               script_name=script_name,
-    #                               execute_after_creation=True,
-    #                               overwrite_script=overwrite_script,
-    #                               save_script=save_script)
+    
 
     # TODO: Fix these eventually 
     @staticmethod

--- a/dpg11_pylib/driver/dpg11.py
+++ b/dpg11_pylib/driver/dpg11.py
@@ -33,7 +33,7 @@ class DPG11Device:
     """
 
     # Hardware limited options
-    internal_clock_rate_limits_in_hz = [50e6, 2.5e9]
+    internal_clock_rate_limits_in_hz = [25e6, 2.5e9]
     device_output_channels = [i for i in range(1, 12)]
     memory_limits = [48, 8e6]
     loops_limits = [0, 2 ** 16 - 2]
@@ -389,7 +389,7 @@ class DPG11Device:
     
     def create_decimal_array(self,
                              stack_arr):
-        return np.apply_along_axis(self.bin_array_to_decimal, 1, stack_arr)
+        return np.apply_along_axis(self.bin_array_to_decimal, 1, stack_arr).astype(int)
 
     #FIXME: Update this to match with the new form for sending wave signals!
     def create_wave_file(self,
@@ -600,14 +600,14 @@ class DPG11Device:
 
     # Function to set the clock frequency
     def set_clk_rate(self,
-                     clock_rate: float,
+                     clock_rate: float or int,
                      execute: bool = False):
         """
         Function that will output the set_clk_rate command string to be input into the command_list parameter of create_script()
 
         Parameters
         ----------
-        clock_rate : float
+        clock_rate : float | int
             What to set the clock rate of the DPG11 as. Must be between 50 MHz and 2.5 GHz
         execute: bool, optional
             If true, creates an executes a single-line script with just this function, by default False
@@ -618,21 +618,24 @@ class DPG11Device:
             SetClkRate command string
         """
         # Check for input type errors     
-        annotations = inspect.getfullargspec(self.set_clk_rate).annotations
-        for i in annotations.keys():
-            if type(locals()[i]) != annotations[i]:
-                raise TypeError(
-                    f'{i} must be of type {annotations[i]} (Received input of type {type(locals()[i])})')
+        # annotations = inspect.getfullargspec(self.set_clk_rate).annotations
+        # for i in annotations.keys():
+        #     if type(locals()[i]) != annotations[i]:
+        #         raise TypeError(
+        #             f'{i} must be of type {annotations[i]} (Received input of type {type(locals()[i])})')
+        
+        if not isinstance(clock_rate, (float, int)):
+            raise TypeError("clock_rate must be of type float or int")
 
                 # Check range of set frequency
         if not (self.internal_clock_rate_limits_in_hz[0] <= clock_rate <=
                 self.internal_clock_rate_limits_in_hz[1]):
             raise ValueError('Data Generator internal frequency input should be between 25e6 Hz and 2.5e9 Hz')
 
-        func_str = f'SetClkRate {self.card_number} {clock_rate}'
+        func_str = f'SetClkRate {self.card_number} {int(clock_rate)}'
 
         # Update the clock frequency variable
-        self.clock_rate = clock_rate
+        self.clock_rate = int(clock_rate)
 
         # For running executing a single-line script when execute set to True
         if execute:

--- a/dpg11_pylib/driver/dpg11.py
+++ b/dpg11_pylib/driver/dpg11.py
@@ -2,9 +2,6 @@
 # This is the old library that I had created. I will delete this library once I have added everything over
 
 # TODO: Update the info for when this file was created
-# 2021-07-06 / last updated on
-# This code was made for use in the Fu lab
-# by Ethan Hansen
 
 import os
 import shutil
@@ -15,12 +12,7 @@ import numpy as np
 
 import inspect
 
-# from qt3utils.pulsers import qcsapphire, pulseblaster
-# from qt3utils.experiments import cwodmr
 
-
-# TODO: Get the class updated to work with the script method
-# TODO: Add proper docstrings for all of the functions, update the error calling using that new function
 # TODO: Organize the workspace
 
 # TODO: Remove all of the verbose from the functions
@@ -32,8 +24,9 @@ class DPG11Device:
     generators untilizing the script method. 
     """
 
+    # TODO: Change these to be all caps bc they are constants
     # Hardware limited options
-    internal_clock_rate_limits_in_hz = [25e6, 2.5e9]
+    internal_clock_rate_limits_in_hz = [50e6, 2.5e9]
     device_output_channels = [i for i in range(1, 12)]
     memory_limits = [48, 8e6]
     loops_limits = [0, 2 ** 16 - 2]
@@ -45,7 +38,7 @@ class DPG11Device:
     def __init__(self,
                  driver_path: str,
                  card_number: int = 1,
-                 open_api_on_initialization: bool = True,
+                 open_api_on_initialization: bool = False,
                  clock_rate=None):
         """
         Initialize DPG11 script method library for controlling the DPG11. This script method is functional but does not return
@@ -69,7 +62,7 @@ class DPG11Device:
         """
         
         # Remove this later, just so the class works for now
-        self.verbose = 3
+        self.verbose = 0
         
         # init the driver path
         self.directory = driver_path
@@ -174,7 +167,6 @@ class DPG11Device:
         create_multi_segments() \n
         pwr_dwn()
         """
-        # TODO: Update the allowable functions list
 
         # Save script text file local path
         script_path = self.scripts_path + f'/{script_name}.txt'
@@ -189,8 +181,6 @@ class DPG11Device:
             if type(locals()[i]) != annotations[i]:
                 raise TypeError(
                     f'{i} must be of type {annotations[i]} (Received input of type {type(locals()[i])})')
-
-        # TODO: Add print-outs for whether the scripts will be deleted or saved or whatever. Also printed after the execution
 
         # Ensure that all elements in command_list
         if not all(isinstance(elem, str) for elem in command_list):
@@ -315,6 +305,11 @@ class DPG11Device:
                            ):
         """
         Sends a command to the API to stop the output of the DPG11 and set the clock rate
+        
+        Parameters
+        ----------
+        clock_rate : float
+            What to set the clock rate of the DPG11 as. Must be between 50 MHz and 2.5 GHz
         """
         # Stop the output
         self.create_script([self.stop(),
@@ -343,7 +338,7 @@ class DPG11Device:
 
     # Small little function to get the number of points from the filename
     def get_data_from_fn(self,
-                         filename: str):
+                         filename: str) -> int:
         """
         Simple function to extract the data from single and multi-wave .txt files. 
         The .txt files should be of the form [filename_data.txt], where data is the data we wish to extract.
@@ -384,17 +379,42 @@ class DPG11Device:
 
     # For creating the wave files
     def bin_array_to_decimal(self,
-                             bin_arr: None):
+                             bin_arr: None) -> int:
+        '''
+        Function to convert a binary array to a decimal number. Used for creating DPG11 wavefiles.
+        
+        Parameters
+        ----------
+        bin_arr : np.ndarray
+            Binary array to convert to decimal.
+            
+        Returns
+        -------
+        int
+            Decimal number of the binary array
+        '''
         return int(''.join(str(bit) for bit in bin_arr), 2)
     
     def create_decimal_array(self,
-                             stack_arr):
+                             stack_arr) -> np.ndarray:
+        '''
+        Function to convert a stacked binary array to a decimal array. Used for creating DPG11 wavefiles.
+        
+        Parameters
+        ----------
+        stack_arr : np.ndarray
+            Stacked binary array to convert to decimal.
+            
+        Returns
+        -------
+        np.ndarray
+            Decimal array of the binary array
+        '''
         return np.apply_along_axis(self.bin_array_to_decimal, 1, stack_arr).astype(int)
 
-    #FIXME: Update this to match with the new form for sending wave signals!
     def create_wave_file(self,
                          wave_name: str,
-                         wave_dict: dict):
+                         wave_dict: dict) -> str:
         """
         This functions creates a .txt wavefile from a waveform array in the proper format to be used by the API.
 
@@ -403,8 +423,8 @@ class DPG11Device:
         wave_name : str
             What to name the wavefile. Do not include .txt. The final file name will be wave_name_{num_points}.txt
         wave_dict : dict
-            Waveform array dictionary of the form {1: 'path for channel 1 array',
-                                                   3: 'path for channel 3 array'}
+            Waveform array dictionary of the form {1: 'ch1_waveform_array',
+                                                   3: 'ch3_waveform_array'}
             and so on and so forth, where channel 1 array is the array of 1's and 0 of whether the channel is on or off.
             Note that you do not need to fill any of the off channels.
 
@@ -418,7 +438,6 @@ class DPG11Device:
         
         # print('Number of Points: ', num_points)
         # Eventual name for the wave file to be saved as
-        # TODO: Fix this, really work on the naming convention, I don't like how I did it
         wave_filename = f'wavefiles/{wave_name}_{num_points}.txt'
         wave_filepath = self.directory + '/' + wave_filename
         # Creating the null array of zeros to be filled to off channels
@@ -430,11 +449,11 @@ class DPG11Device:
         decimal_arr = self.create_decimal_array(stacked_arr)
         
         # Check for correct inputs
-        # annotations = inspect.getfullargspec(self.create_wave_file).annotations
-        # for i in annotations.keys():
-        #     if type(locals()[i]) != annotations[i]:
-        #         raise TypeError(
-        #             f'{i} must be of type {annotations[i]} (Received input of type {type(locals()[i])})')
+        annotations = inspect.getfullargspec(self.create_wave_file).annotations
+        for i in annotations.keys():
+            if type(locals()[i]) != annotations[i]:
+                raise TypeError(
+                    f'{i} must be of type {annotations[i]} (Received input of type {type(locals()[i])})')
 
         # Check if the name is correct
         if ' ' in wave_name:
@@ -460,13 +479,12 @@ class DPG11Device:
         return wave_filename
 
     # Function to create the .txt file that includes the individual waveforms for the create_segments function
-    #FIXME: Change the documentation for this!!!
     def create_multi_wave_file(self,
                                name: str,
-                               filename_arr,
-                               num_loops_arr,
-                               triggered_arr
-                               ):
+                               filename_arr: list,
+                               num_loops_arr: list,
+                               triggered_arr: list
+                               ) -> str:
         """
         This function creates the txt file of the format to send multi-wave segments to be used by the create_multi_segments function.
 
@@ -474,9 +492,13 @@ class DPG11Device:
         ----------
         name : str
             What to name multi-wave file. Do not include the .txt. The final filename should be of the form name_{num_waves}.txt
-        waves_df : pd.DataFrame
-            Dataframe with the multi-wave information. It should have the keys ['filenames', 'num_loops', 'triggered'].
-
+        filename_arr : list
+            List of the filenames of the wavefiles to be used in the multi-wave file
+        num_loops_arr : list
+            List of the number of loops for each wavefile in the multi-wave file
+        triggered_arr : list
+            List of the triggered values for each wavefile in the multi-wave file
+            
         Returns
         -------
         str
@@ -529,12 +551,11 @@ class DPG11Device:
 
         return filename
 
-    # TODO: Add all of the type errors and what not for all of these functions and the docstrings
     # All of the functions to be sent to the DPG11 that will output strings for our case
     # Function to run the waveforms 
     def run(self,
             soft_trig: bool = True,
-            execute: bool = False):
+            execute: bool = False) -> str:
         """
         Function that will output the string required for the .txt script to run saved waves on a channel
 
@@ -562,17 +583,16 @@ class DPG11Device:
         func_str = f'Run {self.card_number} {soft_trig_lower}'
 
         if execute:
-            return self.create_script(command_list=[func_str],
-                                      script_name='temp_run',
-                                      execute_after_creation=True,
-                                      overwrite_script=True,
-                                      save_script=False)
-        else:
-            return func_str
+            self.create_script(command_list=[func_str],
+                               script_name='temp_run',
+                               execute_after_creation=True,
+                               overwrite_script=True,
+                               save_script=False)
+        return func_str
 
     # Function to stop running the waveforms
     def stop(self,
-             execute: bool = False):
+             execute: bool = False) -> str:
         """
         Function to output the Stop command string
         
@@ -590,18 +610,17 @@ class DPG11Device:
 
         # For running executing a single-line script when execute set to True
         if execute:
-            return self.create_script(command_list=[func_str],
-                                      script_name='temp_stop',
-                                      execute_after_creation=True,
-                                      overwrite_script=True,
-                                      save_script=False)
-        else:
-            return func_str
+            self.create_script(command_list=[func_str],
+                               script_name='temp_stop',
+                               execute_after_creation=True,
+                               overwrite_script=True,
+                               save_script=False)
+        return func_str
 
     # Function to set the clock frequency
     def set_clk_rate(self,
                      clock_rate: float or int,
-                     execute: bool = False):
+                     execute: bool = False) -> str:
         """
         Function that will output the set_clk_rate command string to be input into the command_list parameter of create_script()
 
@@ -618,11 +637,11 @@ class DPG11Device:
             SetClkRate command string
         """
         # Check for input type errors     
-        # annotations = inspect.getfullargspec(self.set_clk_rate).annotations
-        # for i in annotations.keys():
-        #     if type(locals()[i]) != annotations[i]:
-        #         raise TypeError(
-        #             f'{i} must be of type {annotations[i]} (Received input of type {type(locals()[i])})')
+        annotations = inspect.getfullargspec(self.set_clk_rate).annotations
+        for i in annotations.keys():
+            if type(locals()[i]) != annotations[i]:
+                raise TypeError(
+                    f'{i} must be of type {annotations[i]} (Received input of type {type(locals()[i])})')
         
         if not isinstance(clock_rate, (float, int)):
             raise TypeError("clock_rate must be of type float or int")
@@ -630,7 +649,7 @@ class DPG11Device:
                 # Check range of set frequency
         if not (self.internal_clock_rate_limits_in_hz[0] <= clock_rate <=
                 self.internal_clock_rate_limits_in_hz[1]):
-            raise ValueError('Data Generator internal frequency input should be between 25e6 Hz and 2.5e9 Hz')
+            raise ValueError('Data Generator internal frequency input should be between 50e6 Hz and 2.5e9 Hz')
 
         func_str = f'SetClkRate {self.card_number} {int(clock_rate)}'
 
@@ -639,26 +658,42 @@ class DPG11Device:
 
         # For running executing a single-line script when execute set to True
         if execute:
-            return self.create_script(command_list=[func_str],
-                                      script_name='temp_set_clk_rate',
-                                      execute_after_creation=True,
-                                      overwrite_script=True,
-                                      save_script=False)
-        else:
-            return func_str
+            self.create_script(command_list=[func_str],
+                               script_name='temp_set_clk_rate',
+                               execute_after_creation=True,
+                               overwrite_script=True,
+                               save_script=False)
+        
+        return func_str
 
+    # Function to set external trigger
     def select_trigger(self,
                        trigger: bool = False,
-                       execute: bool = False):
+                       execute: bool = False) -> str:
+        '''
+        Function to output the SelExtTrig command string
+        
+        Parameters
+        ----------
+        trigger : bool, optional
+            If True, then the DPG11 will use the external trigger, by default False
+        execute: bool, optional
+            If True, creates an executes a single-line script with just this function, by default False
+            
+        Returns
+        -------
+        str
+            SelExtTrig command string
+        '''
 
         func_str = f'SelExtTrig {self.card_number} {str(trigger).lower()}'
 
         if execute:
-            return self.create_script(command_list=[func_str],
-                                      script_name='temp_sel_ext_trig',
-                                      execute_after_creation=True,
-                                      overwrite_script=True,
-                                      save_script=False)
+            self.create_script(command_list=[func_str],
+                               script_name='temp_sel_ext_trig',
+                               execute_after_creation=True,
+                               overwrite_script=True,
+                               save_script=False)
         else:
             return func_str
 
@@ -670,7 +705,7 @@ class DPG11Device:
                               pad_begin: int = 2047,
                               pad_end: int = 2047,
                               triggered: int = 1,
-                              execute: bool = False):
+                              execute: bool = False) -> str:
         """
         Function to output the CreateSingleSegment command string
 
@@ -732,13 +767,12 @@ class DPG11Device:
 
         # For running executing a single-line script when execute set to True
         if execute:
-            return self.create_script(command_list=[func_str],
-                                      script_name='temp_create_single_segment',
-                                      execute_after_creation=True,
-                                      overwrite_script=True,
-                                      save_script=True)
-        else:
-            return func_str
+            self.create_script(command_list=[func_str],
+                               script_name='temp_create_single_segment',
+                               execute_after_creation=True,
+                               overwrite_script=True,
+                               save_script=True)
+        func_str
 
     # Function to create multiple segments
     def create_multi_segments(self,
@@ -747,7 +781,7 @@ class DPG11Device:
                               pad_begin: int = 2047,
                               pad_end: int = 2047,
                               loop: bool = False,
-                              execute: bool = False):
+                              execute: bool = False) -> str:
         """
         Function to output the CreateSegments command string
 
@@ -796,17 +830,16 @@ class DPG11Device:
 
         # For running executing a single-line script when execute set to True
         if execute:
-            return self.create_script(command_list=[func_str],
-                                      script_name='temp_create_multi_segments',
-                                      execute_after_creation=True,
-                                      overwrite_script=True,
-                                      save_script=True)
-        else:
-            return func_str
+            self.create_script(command_list=[func_str],
+                               script_name ='temp_create_multi_segments',
+                               execute_after_creation=True,
+                               overwrite_script=True,
+                               save_script=True)
+        func_str
 
     # Function to power down
     def pwr_dwn(self,
-                execute: bool = False):
+                execute: bool = False) -> str or int:
         """
         Function to output the PWR_DWN command string
 
@@ -834,7 +867,7 @@ class DPG11Device:
 
     # Function to initialize
     def pwr_dwn(self,
-                execute: bool = False):
+                execute: bool = False) -> str:
         """
         Function to output the PWR_DWN command string
 
@@ -852,16 +885,18 @@ class DPG11Device:
 
         # For running executing a single-line script when execute set to True
         if execute:
-            return self.create_script(command_list=[func_str],
-                                      script_name='temp_pwr_down',
-                                      execute_after_creation=True,
-                                      overwrite_script=True,
-                                      save_script=False)
-        else:
-            return func_str
+            self.create_script(command_list=[func_str],
+                               script_name='temp_pwr_down',
+                               execute_after_creation=True,
+                               overwrite_script=True,
+                               save_script=False)
+        func_str
 
     # Just for getting what the clock rate was last set to
-    def get_clock_rate(self):
+    def get_clock_rate(self) -> float or int:
+        '''
+        Function to return the current sample rate of the DPG11
+        '''
         return self.clock_rate
 
     # Function for creating and running a single wave
@@ -873,11 +908,9 @@ class DPG11Device:
                         pad_begin: int = 2047,
                         pad_end: int = 2047,
                         triggered: int = 0,
-
                         save_script: bool = False,
                         script_name: str = 'temp_script',
                         overwrite_script: bool = True,
-
                         soft_trig: bool = True):
         """
         This function inputs a single wavefile str and desired clock rate, output channel, number of loops, pad, and triggering options,
@@ -886,27 +919,34 @@ class DPG11Device:
         Parameters
         ----------
         wave_filename : str
-            [description]
+            Name of the .txt wavefile that you have saved and want to run
         clock_rate : float
-            [description]
+            What to set the dpg11 clock rate to. Must be between 50 MHz and 2.5 GHz
         channel_num : int, optional
-            [description], by default 1
+            Device to run the signal on, by default 1
         num_loops : int, optional
-            [description], by default 0
+            Number of loops to run. 0 loops will go continuously, by default 0
         pad_begin : int, optional
-            [description], by default 2047
+            Not needed for DPG11, but is used for the other wavepond devices, by default 2047
         pad_end : int, optional
-            [description], by default 2047
+            Not needed for DPG11, but is used for the other wavepond devices, by default 2047
         triggered : int, optional
-            [description], by default 0
+            0 => Waveform starts up first time but cannot be triggered later without shutting down first. 
+            1 => Allows waveform to be triggered more than once while running., by default 0
         save_script : bool, optional
-            [description], by default False
+            Whether to save the script file, or delete it after running, by default False
         script_name : str, optional
-            [description], by default 'temp_script'
+            What to name the script, only useful if save_script is True, by default 'temp_script'
         overwrite_script : bool, optional
-            [description], by default True
+            Choose whether or not you want to overwrite scripts with the same name, by default True
         soft_trig : bool, optional
-            [description], by default True
+            Whether to provde a software trig to run the waveform after the run function is applied, 
+            or wait for an external trigger if False, by default True
+            
+        Returns
+        -------
+        str or int
+            The filename of the saved script if save_script is True, or 0 if save_script is False
 
         """
         # TODO: Update for all of the error raising eventually
@@ -965,53 +1005,3 @@ class DPG11Device:
                                   overwrite_script=overwrite_script,
                                   save_script=save_script)
 
-    
-
-    # TODO: Fix these eventually 
-    @staticmethod
-    def join_pattern_arrays(pattern_list):
-        if not (isinstance(pattern_list, np.ndarray) or isinstance(pattern_list, list)):
-            raise TypeError('Pattern_list in not numpy.ndarray or list type')
-        if not (np.all([isinstance(pattern, np.ndarray) for pattern in pattern_list]) or
-                np.all([isinstance(pattern, list) for pattern in pattern_list])):
-            raise TypeError('One or more patterns in pattern_list are of different type AND/OR'
-                            ' not numpy.ndarray or list type.')
-
-        # take an empty numpy.ndarray and append each pattern given in the pattern list, with index priority
-        # (1st pattern is first in the final pattern, 2nd pattern is second in the final pattern etc.)
-        final_pattern = np.array(np.concatenate(pattern_list, axis=0))
-
-        return final_pattern
-
-    # TODO: Fix these later, update them to have everything that we need 
-    @staticmethod
-    def repeat_pattern_array(pattern_array, repetitions):
-        if not isinstance(pattern_array, np.ndarray) or not isinstance(pattern_array, list):
-            raise TypeError('Pattern_array in not numpy.ndarray or list type')
-
-        # similar to join_pattern_arrays, takes a zero numpy.ndarray & adds to it the given pattern 'repetitions' times
-        final_pattern_array = np.array([])
-        for j in range(repetitions):
-            final_pattern_array = np.append(final_pattern_array, pattern_array)
-
-        return final_pattern_array
-
-    def generate_OFF_pattern_array(self, length=None):
-        # returns an array of zeros, of the specified length
-        pattern = np.zeros(length, dtype=int)
-        return pattern
-
-    def generate_ON_pattern_array(self, length=None):
-        # returns an array of ones, of the specified length
-        pattern = np.ones(length, dtype=int)
-        return pattern
-
-    def generate_OFF_ON_pattern_array(self, size=1, length=None):
-        # returns an array of zeros-ones, of the specified length. Step size is determined from size
-        pattern = np.array([int(np.ceil((i + 1 + size) / size) % 2) for i in range(length)])
-        return pattern
-
-    def generate_ON_OFF_pattern_array(self, size=1, length=None):
-        # returns an array of ones-zeros, of the specified length. Step size is determined from size
-        pattern = np.array([int(np.ceil((i + 1) / size) % 2) for i in range(length)])
-        return pattern

--- a/dpg11_pylib/visualization/plotting.py
+++ b/dpg11_pylib/visualization/plotting.py
@@ -3,6 +3,8 @@ import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib.gridspec as gridspec
 from matplotlib.ticker import MultipleLocator, AutoLocator
+# import the waveforms module
+from dpg11_pylib import waveforms
 # import the local libraries
 from dpg11_pylib.visualization.colors import get_color, get_color_list
 
@@ -57,12 +59,33 @@ def plot_waveforms(waveforms: list,
                    x_starts = None,
                    grid_spacing: list = [8, 2],
                    figure_width: int or float = 10):
-    # add the docstrings
+    # docstrings
+    """
+    Plot a list of waveforms.
+    
+    Parameters
+    ----------
+    waveforms : list
+        List of waveforms to plot.
+    labels : list
+        List of labels for the waveforms.
+    x_starts : list, optional
+        List of x_starts for each waveform. Default is None.
+    grid_spacing : list, optional
+        List of the major and minor grid spacing. Default is [8, 2].
+    figure_width : int or float, optional
+        Width of the figure. Default is 10.
+
+    Returns
+    -------
+    None
+    """
+    
     # TODO: Add these docstrings
     # Create the color schemes
     # TODO: replace this with a predefined color scheme in the colors library
     # TODO: fix if the colors arr is shorter than the
-    colors = ['cyan', 'orange', 'lime', 'violet', 'pink', 'red']
+    colors = ['cyan', 'orange', 'lime', 'violet', 'pink', 'red', 'yellow', 'blue', 'grape', 'green', 'gray']
     # Create a colors array
     main_colors = get_color_list(colors, shade=5)
     fill_colors = get_color_list(colors, shade=3)
@@ -128,6 +151,50 @@ def plot_waveforms(waveforms: list,
         
     # return 
     return
+
+# Function to plot the waveforms from a dpg11 wavefile
+def plot_dpg11_wavefile(wavefile: str,
+                        grid_spacing: list = [8, 2],
+                        figure_width: int or float = 10,
+                        plot_channels: list = None):
         
+    '''
+    Plot the all of the waveforms on every channel from a dpg11 wavefile. Or choose the channels to plot.
     
+    Parameters
+    ----------
+    wavefile : str
+        Path to the wavefile to plot.
+    grid_spacing : list, optional
+        List of the major and minor grid spacing. Default is [8, 2].
+    figure_width : int or float, optional
+        Width of the figure. Default is 10.
+    plot_channels : list, optional
+        List of channels to plot. Default is None. None plots all of the channels.
+        
+    Returns
+    -------
+    None
+    '''
     
+    # Get the waveforms array from the wavefile
+    waveforms_arr = waveforms.wavefile2arrays(wavefile)
+    # Get the number of channels
+    if plot_channels == None:
+        channels = np.arange(len(waveforms_arr))
+        waves = waveforms_arr
+    elif isinstance(plot_channels, (list, np.ndarray)):
+        channels = plot_channels
+        waves = [waveforms_arr[i-1] for i in channels]
+    else:
+        raise ValueError("plot_channels must be a list or numpy array")
+    # Get the labels
+    labels = [f'Ch. {i}' for i in channels]
+    
+    # now plot the waveforms 
+    plot_waveforms(waves, 
+                   labels, 
+                   grid_spacing=grid_spacing, 
+                   figure_width=figure_width)
+    
+    return

--- a/dpg11_pylib/visualization/plotting.py
+++ b/dpg11_pylib/visualization/plotting.py
@@ -11,8 +11,6 @@ from dpg11_pylib.visualization.colors import get_color, get_color_list
 # Define function to find the longest length of a waveform when accounting for different x_starts
 def find_longest_waveform(waveforms: list,
                           x_starts: list = None) -> int:
-    # TODO: Add the docstrings
-    # Add the docstrings
     """
     Find the longest waveform in a list of waveforms.
     
@@ -42,34 +40,26 @@ def find_longest_waveform(waveforms: list,
             # return the length of the longest waveform
             return max([(len(wave) + x_starts[i]) for i, wave in enumerate(waveforms)])
 
-"""
-I want to create a function to visualize waveforms here, both np arrays and dpg11 waveforms
-For the DPG11 waveforms, have the option to visualize the outputs on multiple channels, which is an option.
-I will need to write more functions to do this. First, I will create the option to visualize the 
-standard numpy arrays.
-"""
+
 
 # Function to visualize waveforms
-#TODO: Figure out the right way to name this, is it a camel case situation?
-#TODO: Create a function to get the start value
 #TODO: Add the ability to deal with only one waveform and label and what not
-#TODO: Add the docstrings
-def plot_waveforms(waveforms: list,
-                   labels: list,
+
+def plot_waveforms(waveforms: list or np.ndarray,
+                   labels: list or np.ndarray,
                    x_starts = None,
                    grid_spacing: list = [8, 2],
-                   figure_width: int or float = 10):
-    # docstrings
+                   figure_width: int or float = 10) -> None:
     """
     Plot a list of waveforms.
     
     Parameters
     ----------
-    waveforms : list
+    waveforms : list or ndarray
         List of waveforms to plot.
-    labels : list
+    labels : list or ndarray
         List of labels for the waveforms.
-    x_starts : list, optional
+    x_starts : list or ndarray or NoneType, optional
         List of x_starts for each waveform. Default is None.
     grid_spacing : list, optional
         List of the major and minor grid spacing. Default is [8, 2].
@@ -80,8 +70,6 @@ def plot_waveforms(waveforms: list,
     -------
     None
     """
-    
-    # TODO: Add these docstrings
     # Create the color schemes
     # TODO: replace this with a predefined color scheme in the colors library
     # TODO: fix if the colors arr is shorter than the
@@ -156,7 +144,7 @@ def plot_waveforms(waveforms: list,
 def plot_dpg11_wavefile(wavefile: str,
                         grid_spacing: list = [8, 2],
                         figure_width: int or float = 10,
-                        plot_channels: list = None):
+                        plot_channels: list = None) -> None:
         
     '''
     Plot the all of the waveforms on every channel from a dpg11 wavefile. Or choose the channels to plot.

--- a/dpg11_pylib/waveforms/waveforms.py
+++ b/dpg11_pylib/waveforms/waveforms.py
@@ -1,15 +1,70 @@
 # Module for the creation of waveforms and other nice things like that
 import numpy as np
 
-# Create on off waveform that is a numpy array
-#TODO: Fix these names, add the docstrings
-def offOnArray(size=1, length=64):
-    # returns an array of zeros-ones, of the specified length. Step size is determined from size
+# Create on array of desired length
+def on_array(length: int = 64) -> np.ndarray:
+    """
+    Creates an array of ones of length length.
+    
+    Parameters
+    ----------
+    length : int
+        Length of the waveform. Default is 64. The minimum for a dpg11 waveform is 64, and things must be modulo 64,
+        so ensure that it is modulo 64 if working with the dpg11.
+        
+    Returns
+    -------
+    arr : np.ndarray
+        Array of ones of length length.
+    """
+    # create array of ones
+    arr = np.ones(length).astype(int)
+    return arr
+
+# Create off array of desired length
+def off_array(length: int = 64) -> np.ndarray:
+    """
+    Creates an array of zeros of length length.
+    
+    Parameters
+    ----------
+    length : int
+        Length of the waveform. Default is 64. The minimum for a dpg11 waveform is 64, and things must be modulo 64,
+        so ensure that it is modulo 64 if working with the dpg11.
+        
+    Returns
+    -------
+    arr : np.ndarray
+        Array of zeros of length length.
+    """
+    # create array of zeros
+    arr = np.zeros(length).astype(int)
+    return arr
+
+# Create off on waveform that is a numpy array
+def off_on_array(size: int = 1, 
+                 length: int = 64) -> np.ndarray:
+    """
+    Creates an array of zeros and ones of length length. The width of the steps are determined by size.
+    
+    Parameters
+    ----------
+    size : int
+        Width of the steps in the waveform. Default is 1. Maybe be set to the freq. multiplier if
+        downconverting the frequency.
+    length : int
+        Length of the waveform. Default is 64. The minimum for a dpg11 waveform is 64, and things must be modulo 64,
+        so ensure that it is modulo 64 if working with the dpg11.
+        
+    
+    """
+    # create the array of zeros and ones
     arr = np.array([int(np.ceil((i + 1 + size) / size) % 2) for i in range(length)])
     return arr
 
-#TODO: Fix the names of these functions
-def onOffArray(size=1, length=64):
+# Create on off waveform that is a numpy array
+def on_off_array(size: int = 1, 
+                 length: int = 64) -> np.ndarray:
     '''
     Creates an array of ones and zeros of length length. The width of the steps are determined by size.
     This is a 50% duty cycle waveform. 
@@ -28,13 +83,13 @@ def onOffArray(size=1, length=64):
     arr : np.ndarray
         Array of ones and zeros of length length.
     '''
-    # returns an array of ones-zeros, of the specified length. Step size is determined from size
+    # create array of zeros and ones
     arr = np.array([int(np.ceil((i + 1) / size) % 2) for i in range(length)])
     return arr
 
 # Create function to get the multiplier to downconvert to the DPG11 clock frequency
 def downconvert_clock_frequency(clock_frequency: float or int,
-                                min_sample_rate: int or int = 25e6) -> (int, int):
+                                min_sample_rate: int or int = 50e6) -> (int, int):
     """
     Emulate the clock frequency of the DPG11. It will determine an integer multiplier (frequency_multiplier) to
     multiply the desired frequency (clock_frequency) by to get the sample rate above the minimum limit of the
@@ -197,3 +252,44 @@ def wavefile2arrays(wavefile: str) -> list or np.ndarray:
     waveforms_arr = bin_waveforms.T
     
     return waveforms_arr
+
+# Function to join multiple waveforms together in the order given
+def join_waveforms(waveform_arr: np.ndarray or list) -> np.ndarray:
+    """
+    Join multiple waveforms together in the order given, creating one long waveform.
+    
+    Parameters
+    ----------
+    waveform_arr : np.ndarray | list
+        Array of waveforms to join together.
+        
+    Returns
+    -------
+    joined_waveform : np.ndarray
+        Joined waveform.
+    """
+    # Join the waveforms together
+    return np.concatenate(waveform_arr)
+
+# Function to repeat a waveform a given number of times and join them together into one
+def repeat_waveform(waveform: np.ndarray or list,
+                    num_repeats: int) -> np.ndarray:
+    """
+    Repeat a waveform a given number of times and join them together into one.
+    
+    Parameters
+    ----------
+    waveform : np.ndarray | list
+        Waveform to repeat.
+    num_repeats : int
+        Number of times to repeat the waveform.
+        
+    Returns
+    -------
+    repeated_waveform : np.ndarray
+        Repeated waveform.
+    """
+    # Repeat the waveform
+    repeated_waveform = np.tile(waveform, num_repeats)
+    
+    return repeated_waveform

--- a/dpg11_pylib/waveforms/waveforms.py
+++ b/dpg11_pylib/waveforms/waveforms.py
@@ -140,9 +140,9 @@ def pad_waveform(waveform: np.ndarray or list,
     
     # Pad the waveform
     if pad_side == 'right':
-        waveform = np.pad(waveform, (pad_value, num_samples_to_pad), constant_values=pad_value)
+        waveform = np.pad(waveform, (pad_value, num_samples_to_pad), constant_values=pad_value).astype(int)
     elif pad_side == 'left':
-        waveform = np.pad(waveform, (num_samples_to_pad, pad_value), constant_values=pad_value)
+        waveform = np.pad(waveform, (num_samples_to_pad, pad_value), constant_values=pad_value).astype(int)
     else:
         raise ValueError('pad_side must be either "right" or "left"')
     

--- a/dpg11_pylib/waveforms/waveforms.py
+++ b/dpg11_pylib/waveforms/waveforms.py
@@ -10,6 +10,190 @@ def offOnArray(size=1, length=64):
 
 #TODO: Fix the names of these functions
 def onOffArray(size=1, length=64):
+    '''
+    Creates an array of ones and zeros of length length. The width of the steps are determined by size.
+    This is a 50% duty cycle waveform. 
+    
+    Parameters
+    ----------
+    size : int
+        Width of the steps in the waveform. Default is 1. Maybe be set to the freq. multiplier if 
+        downconverting the frequency.
+    length : int
+        Length of the waveform. Default is 64. The minimum for a dpg11 waveform is 64, and things must be modulo 64,
+        so ensure that it is modulo 64 if working with the dpg11.
+        
+    Returns
+    -------
+    arr : np.ndarray
+        Array of ones and zeros of length length.
+    '''
     # returns an array of ones-zeros, of the specified length. Step size is determined from size
     arr = np.array([int(np.ceil((i + 1) / size) % 2) for i in range(length)])
     return arr
+
+# Create function to get the multiplier to downconvert to the DPG11 clock frequency
+def downconvert_clock_frequency(clock_frequency: float or int,
+                                min_sample_rate: int or int = 25e6) -> (int, int):
+    """
+    Emulate the clock frequency of the DPG11. It will determine an integer multiplier (frequency_multiplier) to
+    multiply the desired frequency (clock_frequency) by to get the sample rate above the minimum limit of the
+    DPG11 (min_sample_rate). Each waveform will then have to be multiplied by this frequency_multiplier to
+    downconvert the frequency to the desired frequency.
+    
+    clock_frequency = sample_rate / frequency_multiplier
+    
+    Parameters
+    ----------
+    clock_frequency : float | int
+        Desired frequency of clock output in Hz.
+    min_sample_rate : float
+        Minimum sample rate of the device. Default is 25e6.
+    sample_rate : float
+        Sample rate of the DAQ card in Hz. Default is 1e9.
+        
+    Returns
+    -------
+    sample_rate : float
+        Sample rate to set the DPG11 to in order to downconvert the frequency.
+    frequency_multiplier : int
+        Multiplier to downconvert the frequency.
+        
+    Examples
+    --------
+    >>> downconvert_clock_frequency(2.5e6)
+    (25e6, 10)
+    """
+    
+    # Determine the frequency multiplier
+    frequency_multiplier = int(np.ceil(min_sample_rate / clock_frequency))
+    
+    # Determine the sample rate
+    sample_rate = int(clock_frequency * frequency_multiplier)
+    
+    return sample_rate, frequency_multiplier
+
+# create function to check if a pulse width if mod 64 given the sample rate
+# then give the mod 64 duration. If not, give the closest duration. 
+def length_mod_64(pulse_width: int,
+                  sample_rate: int) -> (int, float):
+    """
+    Check if the duration of a segment is modulo 64 in samples given the sample rate.
+    
+    Parameters
+    ----------
+    pulse_width : int
+        Pulse width in seconds to check if modulo 64 given the sample rate
+    sample_rate : int
+        Sample rate of the device.
+        
+    Returns
+    -------
+    num_samples_64 : int
+        Number of samples that is modulo 64
+    new_duration : float
+        New duration of the segment in seconds that is mod 64
+    """
+    # get the number of samples from the pulse duration
+    num_samples = pulse_width * sample_rate
+    # Make the number of samples to be modulo
+    num_samples_64 = int(np.ceil(num_samples/64)*64)
+    # and change the pulse width to match
+    duration_64 = num_samples/sample_rate
+
+    
+    return num_samples_64, duration_64
+
+# Define function to pad a given waveform (with either 1s or 0s) to a given length (on the right or left)
+def pad_waveform(waveform: np.ndarray or list,
+                 length: int,
+                 pad_value: int = 0,
+                 pad_side: str = 'right') -> np.ndarray:
+    """
+    Pad a waveform with either 1s or 0s to a given length. 
+    
+    Parameters
+    ----------
+    waveform : np.ndarray
+        Waveform to pad.
+    length : int
+        Length to pad the waveform to.
+    pad_value : int
+        Value to pad the waveform with. Default is 0.
+    pad_side : str
+        Side to pad the waveform on. Default is 'right'.
+        
+    Returns
+    -------
+    waveform : np.ndarray
+        Padded waveform.
+    """
+    # Determine the length of the waveform
+    waveform_length = len(waveform)
+    
+    # Determine the number of samples to pad
+    num_samples_to_pad = length - waveform_length
+    
+    # Raise error if wrong pad value
+    if pad_value not in [0, 1]:
+        raise ValueError('pad_value must be either 0 or 1')
+    
+    # Pad the waveform
+    if pad_side == 'right':
+        waveform = np.pad(waveform, (pad_value, num_samples_to_pad), constant_values=pad_value)
+    elif pad_side == 'left':
+        waveform = np.pad(waveform, (num_samples_to_pad, pad_value), constant_values=pad_value)
+    else:
+        raise ValueError('pad_side must be either "right" or "left"')
+    
+    return waveform
+
+# Function to convert a decimal number to an 11 bit binary array (for the dpg11)
+def dec2bin_array(dec_num: int) -> np.ndarray:
+    """
+    Convert a decimal number to an 11 bit binary array (for the dpg11). Left is the least significant bit.
+    
+    Parameters
+    ----------
+    dec_num : int
+        Decimal number to convert to binary.
+        
+    Returns
+    -------
+    bin_array : np.ndarray
+        Binary array of length 11.
+    """
+    # Convert the decimal number to binary
+    bin_num = bin(int(dec_num))[2:]
+    
+    
+    # Convert the binary number to an array
+    bin_array = [int(i) for i in bin(dec_num)[2:].zfill(11)]
+    bin_array.reverse()
+    
+    return np.array(bin_array)
+
+# Function to fully convert a wavefile to a list of arrays with each entry being a channel
+def wavefile2arrays(wavefile: str) -> list or np.ndarray:
+    """
+    Convert a wavefile to a list of arrays with each entry being a channel. ie wavefile_arrays[0] is channel 1.
+    
+    Parameters
+    ----------
+    wavefile : str
+        Path to the wavefile to convert.
+        
+    Returns
+    -------
+    wavefile_arrays : list | np.ndarray
+        List of arrays with each entry being a channel.
+    """
+    # Open the wavefile
+    dec_waveforms = np.loadtxt(wavefile).astype(int)
+        
+    # Convert each decimal waveform to binary
+    bin_waveforms = np.array([dec2bin_array(i) for i in dec_waveforms])
+    # Transpose the data
+    waveforms_arr = bin_waveforms.T
+    
+    return waveforms_arr


### PR DESCRIPTION
Added many different features to enable the creation of the dpg11 pulser class in qt3utils.

Additions:
- Function to downconvert the frequency of the dpg11 outputs
- Function to get mod 64 length waveforms
- Function to convert dpg11 wavefiles back into waveform arrays for each channel
- Plotting function to plot wavefiles from dpg11 wavefiles
- General waveform creation functions that are helpful
- Created odmr pulser class that will be used in qt3utils for cwodmr
- More that I probably forget here

Other things:
- Added docstrings for all functions
- Fixed some of the styling to align with PEP8 styling
- Removed unecessary functions from dpg11 main driver, moved waveform related functions to waveforms module.
- Changed package version to 0.1.0 in preperation for releasing it. 